### PR TITLE
Fix CI error: Update vcpkg commit ID to latest stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: "896bf4e76e2b72f0e4af12d488d455bd41e0dd57" # Latest stable
+          vcpkgGitCommitId: "ee0973d8090e4e3e452244bb50d34c25fe907dc2" # Latest stable (2025-08-18)
 
       - name: Install OpenSSL via vcpkg (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: lukka/run-vcpkg@v11
         with:
-          vcpkgGitCommitId: "896bf4e76e2b72f0e4af12d488d455bd41e0dd57" # Latest stable
+          vcpkgGitCommitId: "ee0973d8090e4e3e452244bb50d34c25fe907dc2" # Latest stable (2025-08-18)
 
       - name: Install OpenSSL via vcpkg (Windows)
         if: matrix.os == 'windows-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]


### PR DESCRIPTION
- Update vcpkgGitCommitId from invalid commit 896bf4e76e2b72f0e4af12d488d455bd41e0dd57
- Use latest stable commit ee0973d8090e4e3e452244bb50d34c25fe907dc2 (2025-08-18)
- Fixes GitHub Actions build failure in both CI and release workflows
- Resolves fatal error: unable to read tree in vcpkg setup step