### PR TITLE
Create sign_pe_data to allow signing files in-memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ goblin = "0.10.1"
 
 # HTTP client for timestamping
 reqwest = { version = "0.12.23", features = ["rustls-tls", "json"] }
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "fs"] }
 
 # Date/time handling
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Adds function to allow signing file already in memory.
Useful when `yubikey-signer` is used  as a library and file is already read/received elsewhere.