### PR TITLE
feat: add sign_pe_data for in-memory PE signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ goblin = "0.10.1"
 
 # HTTP client for timestamping
 reqwest = { version = "0.12.23", features = ["rustls-tls", "json"] }
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "fs"] }
 
 # Date/time handling
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary

Adds `sign_pe_data()` function to allow signing PE files already loaded in memory, making the library more flexible when files are received from other sources.

**Based on contribution from @olback (#40)**

## Changes

- **New `sign_pe_data<I: AsRef<[u8]>>()`** - Signs PE data in-memory, returns `Vec<u8>`
- **Refactored `sign_pe_file()`** - Now delegates to `sign_pe_data()` for DRY code
- **Async I/O** - Changed to `tokio::fs::read/write` for proper async file operations
- **Tokio feature** - Added `fs` feature to tokio dependency

## Documentation

- Comprehensive rustdoc for both functions
- Code examples showing typical usage patterns
- Cross-references between related functions
- `#[inline]` hints for thin wrappers

## Version

Bumped to `0.4.1`

---

Closes #40 (incorporated with enhancements)