### PR TITLE
feat: add sign_pe_data for in-memory PE signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ goblin = "0.10.1"
 
 # HTTP client for timestamping
 reqwest = { version = "0.12.23", features = ["rustls-tls", "json"] }
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "fs"] }
 
 # HTTP server for proxy (optional)
 warp = { version = "0.3", optional = true, features = ["tls"] }


### PR DESCRIPTION
## Summary

Adds `sign_pe_data()` function to allow signing PE files already loaded in memory, making the library more flexible when files are received from other sources.

**Based on contribution from @olback (#40)**

## Changes

- **New `sign_pe_data<I: AsRef<[u8]>>()`** - Signs PE data in-memory, returns `Vec<u8>`
- **Refactored `sign_pe_file()`** - Now delegates to `sign_pe_data()` for DRY code
- **Async I/O** - Changed to `tokio::fs::read/write` for proper async file operations
- **Tokio feature** - Added `fs` feature to tokio dependency

## Documentation

- Comprehensive rustdoc for both functions with full parameter documentation
- Code examples showing typical usage patterns
- Cross-references between related functions
- `#[inline]` hints for thin wrappers

---

Incorporates and enhances #40 (now closed)