### PR TITLE
fix: use PAT for auto-tag workflow to trigger releases

### DIFF
--- a/.github/workflows/auto-tag-on-merge.yml
+++ b/.github/workflows/auto-tag-on-merge.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
+# Note: We use a PAT (RELEASE_TOKEN) instead of GITHUB_TOKEN to push tags.
+# This is required because tags pushed via GITHUB_TOKEN do NOT trigger other
+# workflows (like the Release workflow). This is a GitHub security feature
+# to prevent infinite workflow loops.
 
 jobs:
   tag-on-version-bump:
@@ -17,6 +19,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Use PAT for checkout so git push uses the same token
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Detect version bump and create tag
         id: autotag


### PR DESCRIPTION
## Problem

Tags pushed via `GITHUB_TOKEN` do **not** trigger other workflows (like the Release workflow). This is a GitHub security feature to prevent infinite workflow loops.

This caused the `v0.5.0` release to not be created automatically when the version was bumped.

## Solution

Use a Personal Access Token (`RELEASE_TOKEN` secret) instead of `GITHUB_TOKEN` for pushing tags. PAT-pushed events **do** trigger other workflows.

## Required Setup

After merging, add a repository secret:

1. **Create a fine-grained PAT** at the link below
2. Add it as a repository secret named `RELEASE_TOKEN`

### PAT Requirements:
- **Repository access**: `dgehri/yubikey-signer`
- **Permissions**: `Contents: Read and write`

---

⚠️ **Do not merge until the `RELEASE_TOKEN` secret is configured!**