### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,9 +686,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "goblin"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51876e3748c4a347fe65b906f2b1ae46a1e55a497b22c94c1f4f2c469ff7673a"
+checksum = "4db6758c546e6f81f265638c980e5e84dfbda80cfd8e89e02f83454c8e8124bd"
 dependencies = [
  "log",
  "plain",
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]
@@ -47,7 +47,7 @@ openssl = "0.10"
 openssl-sys = "0.9"
 
 # PE file manipulation
-goblin = "0.10.1"
+goblin = "0.10.4"
 
 # HTTP client for timestamping
 reqwest = { version = "0.12.23", features = ["rustls-tls", "json"] }
@@ -96,12 +96,12 @@ log = "0.4"
 [build-dependencies]
 ureq = { version = "2.0", default-features = false, features = ["tls"] }
 num_cpus = "1.0"
-cc = "1.0"
+cc = "1.2"
 
 [dev-dependencies]
 # Testing
 hex = "0.4"
-mockall = "0.13.1"
+mockall = "0.14.0"
 tokio-test = "0.4"
 
 [features]


### PR DESCRIPTION
## Summary
Bumps version from 0.5.0 to 0.5.1 and consolidates all dependency updates.

## Version Bump
- `yubikey-signer` 0.5.0 → 0.5.1

## Dependency Updates (supersedes dependabot PRs)
| Dependency | Old | New | PR |
|------------|-----|-----|-----|
| goblin | 0.10.1 | 0.10.4 | #43 |
| cc | 1.0 | 1.2 | #42 |
| log | 0.4.28 | 0.4.29 | #41 |
| mockall | 0.13.1 | 0.14.0 | #39 |
| chrono | 0.4.41 | 0.4.42 | #21 |

Plus additional transitive updates from `cargo update`:
- base64ct, http, hyper-util, icu_properties, libc, mio, reqwest, rustls-pki-types, tower-http, tracing, uuid, wasm-bindgen, winnow, zerocopy

## Notes
On merge, the auto-tag workflow will:
1. Detect the version change in Cargo.toml (0.5.0 → 0.5.1)
2. Create and push tag `v0.5.1`
3. Trigger the release workflow with Windows binary code signing