### PR TITLE
Fix MSI signing for large CFB v4 files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]


### PR DESCRIPTION
## Summary

Fixes #63 - MSI signing fails with "Sector read out of bounds" on WiX-produced MSI files (~23MB+) that use CFB v4 format with 4096-byte sectors.

## Root Cause

Two critical bugs were identified:

### 1. Partial Sector Handling (cfb_writer.rs)

The `read_sector` function failed when the last sector wasn't padded to a full sector boundary. Large CFB v4 files may have a final sector that is smaller than 4096 bytes.

**Fix:** Read available bytes and zero-pad to sector_size.

### 2. Incorrect FAT Chain Traversal (hash.rs)

The `read_stream` function read ALL remaining bytes from a single sector offset instead of capping at `sector_size` per iteration and following the FAT chain. This caused incorrect hash computation for streams larger than one sector (>4096 bytes).

**Fix:** Added `.min(self.sector_size)` to the `bytes_to_read` calculation to ensure proper FAT chain traversal.

### 3. Directory Entry Index Alignment (hash.rs)

Empty directory entries were being filtered out, causing misalignment between entry indices and child/sibling pointers.

**Fix:** Preserve all directory entries (including empty ones) to maintain correct index alignment.

## Testing

- ✅ All unit tests pass (`cargo test`)
- ✅ All 10/10 integration tests pass (`.\scripts\test.ps1`)
- ✅ Successfully signed 23MB WiX-produced MSI file
- ✅ Windows `Get-AuthenticodeSignature` verification: **Valid**