### PR TITLE
Fix #73: re-sign WiX Burn bundles without breaking overlay

### DIFF
--- a/src/domain/pe/mod.rs
+++ b/src/domain/pe/mod.rs
@@ -141,7 +141,8 @@ pub use signed_types::{
 
 pub use hash_view::PeHashView;
 pub use layout::{
-    calculate_pe_checksum, find_certificate_directory_offset, parse_pe, update_pe_checksum,
-    PECertificateDirectory, PeInfo, WinCertificate,
+    calculate_pe_checksum, find_certificate_directory_offset, parse_pe,
+    strip_certificate_table_for_resigning, update_pe_checksum, PECertificateDirectory, PeInfo,
+    WinCertificate,
 };
 pub use parse::{PeParseError, PeRaw};

--- a/src/pipelines/sign.rs
+++ b/src/pipelines/sign.rs
@@ -46,6 +46,9 @@ impl SignWorkflow {
         let output_path = output.as_ref();
         let file_data = std::fs::read(input_path)
             .map_err(|e| SigningError::IoError(format!("Failed to read input file: {e}")))?;
+        // If the input is already signed, strip the existing certificate table before hashing.
+        // This allows re-signing build artifacts without requiring a separate "unsign" step.
+        let file_data = pe::strip_certificate_table_for_resigning(&file_data)?;
         let _ = pe::parse_pe(&file_data)?; // validate early
 
         let mut yubikey_ops = YubiKeyOperations::connect()?;

--- a/src/services/authenticode.rs
+++ b/src/services/authenticode.rs
@@ -943,22 +943,10 @@ impl OpenSslAuthenticodeSigner {
         } else {
             (0, 0)
         };
-
-        // Detect overlay data (bytes after end-of-image). For overlay-bearing files (e.g. WiX Burn
-        // bundles), we embed the certificate table before the overlay, so Authenticode hashing must
-        // *not* apply the unsigned-file 8-byte padding rule.
-        let mut end_of_image = 0usize;
-        if let Some(optional_header) = pe_info.pe.header.optional_header {
-            end_of_image =
-                end_of_image.max(optional_header.windows_fields.size_of_headers as usize);
-        }
-        for section in &pe_info.pe.sections {
-            let start = section.pointer_to_raw_data as usize;
-            let size = section.size_of_raw_data as usize;
-            end_of_image = end_of_image.max(start.saturating_add(size));
-        }
-        end_of_image = end_of_image.min(file_len);
-        let has_overlay = end_of_image < file_len;
+        // Note: We intentionally do not special-case overlays here. Authenticode hashing is defined
+        // over the full file contents while skipping the certificate table bytes (if present).
+        // For unsigned files, hashing pads with zeros up to an 8-byte boundary.
+        let _ = pe_info;
 
         let mut idx = 0;
         let range1_end = header_size + 88;
@@ -984,7 +972,7 @@ impl OpenSslAuthenticodeSigner {
             hasher.update(&pe_data[cursor..file_len]);
         }
 
-        if sigpos == 0 && !has_overlay {
+        if sigpos == 0 {
             let pad_len = 8 - (file_len % 8);
             if pad_len > 0 && pad_len != 8 {
                 hasher.update(&vec![0u8; pad_len]);


### PR DESCRIPTION
## Problem
WiX Burn bundles store their attached container (WixAttachedContainer) in the PE overlay. If signing changes overlay offsets/bytes, Burn can fail to extract the container and abort with errors like `0x80070001`.

## Root cause
Our signing flow could shift/alter overlay data and/or produce hashing/embedding behavior that didn’t match Authenticode expectations for these files.

## Fix
- Preserve overlay bytes and offsets (do not insert bytes before the overlay).
- Keep the certificate table at EOF for Windows compatibility.
- Support re-signing by stripping an existing PE certificate table before hashing/signing.
- Make Authenticode hashing overlay-agnostic (hash full file while skipping the certificate table; unsigned padding applies when no cert table is present).

## Tests
- Updated/added PE overlay regression coverage (`tests/pe_domain_tests.rs`).
- `cargo test` passes.
- `./scripts/test.ps1` passes (remote signing + timestamp + MSI verification).

## Manual verification
- Remote-sign + verify: `Get-AuthenticodeSignature` reports `Valid`, and `signtool verify /pa` succeeds.
- Burn `/layout` succeeds (ExitCode 0) and produces `linkcad-setup.exe` in the layout directory.

Fixes #73.