### PR TITLE
fix: compute Authenticode hash only over PE image proper (exclude overlay)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]


### PR DESCRIPTION
## Summary

Fixes Authenticode hash computation for PE files with overlay data (e.g., WiX Burn bundles). The hash now correctly covers only the PE image proper, excluding appended data.

Closes #76

## Changes

- Added `compute_end_of_image()` helper that calculates the end of PE raw data by examining section headers
- Modified `hash_pe_file_for_spc_creation()` to use `end_of_image` instead of `file_len` for unsigned files
- Corrected padding calculation to use `(8 - (end_of_image % 8)) % 8`

## Background

WiX Burn bundles are PE files with large overlay data (attached MSI containers). For a 23MB bundle, only ~500KB is the actual PE image. The previous code was hashing all 23MB, causing signature verification failures.

## Important Note

This fix corrects the hash computation, but **overlay-bearing files cannot be signed directly** due to MS12-024 requirements (signature must be at EOF). Use WiX `insignia.exe` detach/sign/reattach workflow for Burn bundles.

## Testing

- All 155 tests pass
- `scripts/test.ps1` passes (remote signing)
- Manual verification: normal PE files sign correctly with `Valid` status