### PR TITLE
fix: require 8-byte alignment for WIN_CERTIFICATE in overlay files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]


### PR DESCRIPTION
## What'\''s Changed

### Bug Fixes
- **Fix 8-byte alignment requirement for WIN_CERTIFICATE in overlay-bearing PE files**
  
  Windows requires the WIN_CERTIFICATE structure to start at an 8-byte aligned offset. For overlay-bearing files (e.g., WiX Burn bundles), the signature position was not being aligned, causing Windows to reject signatures with error 0x80096010.
  
  The fix adds padding bytes after the overlay (before the signature) to ensure proper alignment, and includes this padding in the Authenticode hash computation.

### Commits
- `fix: require 8-byte alignment for WIN_CERTIFICATE in overlay files`
- `chore: bump version to 0.7.3`