### PR TITLE
fix(sign): use config timestamp defaults and explicit disable semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
             target/${{ matrix.target }}/release/yubikey-signer${{ matrix.binary-suffix }}
             target/${{ matrix.target }}/release/yubikey-proxy${{ matrix.binary-suffix }}
           if-no-files-found: error
+          overwrite: true
 
   # Cross-compile yubikey-proxy for ASUS routers and similar aarch64 embedded devices
   # Uses Docker-based build to match the Dockerfile.aarch64-direct-usb setup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-signer"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-signer"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "YubiKey code signing utility"
 authors = ["Daniel Gehriger <gehriger@linkcad.com>"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ yubikey-signer sign myapp.exe
 Without timestamping (not recommended for production):
 
 ```bash
-yubikey-signer sign myapp.exe --timestamp ""
+yubikey-signer sign myapp.exe --no-timestamp
 ```
 
 ### PIV Slot Selection
@@ -222,7 +222,8 @@ Arguments:
 Options:
   -o, --output <FILE>       Output file (default: sign in-place)
   -s, --slot <SLOT>         PIV slot (hex: 0x9c, 9c, or decimal: 156)
-  -t, --timestamp [<URL>]   Timestamp URL override (omit value to use config defaults; empty string disables)
+  -t, --timestamp <URL>     Timestamp server URL override (absent = use configured defaults)
+      --no-timestamp        Disable timestamping explicitly
   -r, --remote <URL>        Remote signing proxy URL
       --header <HEADER>     Custom HTTP header (format: "Name: Value"), repeatable
       --dry-run             Preview signing without making changes

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Arguments:
 Options:
   -o, --output <FILE>       Output file (default: sign in-place)
   -s, --slot <SLOT>         PIV slot (hex: 0x9c, 9c, or decimal: 156)
-  -t, --timestamp [<URL>]   Timestamp server URL override (empty string disables timestamping)
+  -t, --timestamp [<URL>]   Timestamp URL override (omit value to use config defaults; empty string disables)
   -r, --remote <URL>        Remote signing proxy URL
       --header <HEADER>     Custom HTTP header (format: "Name: Value"), repeatable
       --dry-run             Preview signing without making changes

--- a/README.md
+++ b/README.md
@@ -59,10 +59,18 @@ yubikey-signer sign myapp.exe -o signed.exe \
 
 ### Timestamping
 
+Timestamping is enabled by default using the configured primary timestamp server.
+
 With timestamp server:
 
 ```bash
 yubikey-signer sign myapp.exe --timestamp http://timestamp.digicert.com
+```
+
+Use config-managed defaults (primary + fallback servers):
+
+```bash
+yubikey-signer sign myapp.exe
 ```
 
 Without timestamping (not recommended for production):
@@ -214,7 +222,7 @@ Arguments:
 Options:
   -o, --output <FILE>       Output file (default: sign in-place)
   -s, --slot <SLOT>         PIV slot (hex: 0x9c, 9c, or decimal: 156)
-  -t, --timestamp [<URL>]   Timestamp server URL (default: http://ts.ssl.com)
+  -t, --timestamp [<URL>]   Timestamp server URL override (empty string disables timestamping)
   -r, --remote <URL>        Remote signing proxy URL
       --header <HEADER>     Custom HTTP header (format: "Name: Value"), repeatable
       --dry-run             Preview signing without making changes

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -161,13 +161,12 @@ function Test-YubikeySignerSign {
         }
         
         if ($WithTimestamp) {
-            $cmdArgs += "--timestamp"
+            # Rely on configured default timestamp server (no --timestamp flag needed)
         }
         else {
             # Timestamping is enabled by default via configuration; explicitly disable it
             # when validating non-timestamped outputs.
-            $cmdArgs += "--timestamp"
-            $cmdArgs += ""
+            $cmdArgs += "--no-timestamp"
         }
         if ($Verbose) {
             $cmdArgs += "--verbose"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -163,6 +163,12 @@ function Test-YubikeySignerSign {
         if ($WithTimestamp) {
             $cmdArgs += "--timestamp"
         }
+        else {
+            # Timestamping is enabled by default via configuration; explicitly disable it
+            # when validating non-timestamped outputs.
+            $cmdArgs += "--timestamp"
+            $cmdArgs += ""
+        }
         if ($Verbose) {
             $cmdArgs += "--verbose"
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -117,6 +117,8 @@ struct Cli {
     command: Commands,
 }
 
+const TIMESTAMP_USE_CONFIG_SENTINEL: &str = "__USE_CONFIG_DEFAULTS__";
+
 #[derive(Subcommand)]
 enum Commands {
     /// Sign a PE or MSI file
@@ -133,8 +135,8 @@ enum Commands {
         #[arg(short, long, value_name = "SLOT", default_value = "9a")]
         slot: String,
 
-        /// Timestamp server URL (use without value for default server)
-        #[arg(short, long, value_name = "URL", num_args = 0..=1, default_missing_value = "http://ts.ssl.com")]
+        /// Timestamp server URL (omit value to use configuration defaults)
+        #[arg(short, long, value_name = "URL", num_args = 0..=1, default_missing_value = "__USE_CONFIG_DEFAULTS__")]
         timestamp: Option<String>,
 
         /// Remote `YubiKey` proxy URL (e.g., <https://yubikey.example.com>)
@@ -246,6 +248,12 @@ struct SignCommandArgs {
     verbose: bool,
 }
 
+#[derive(Clone)]
+struct TimestampSettings {
+    url: Option<TimestampUrl>,
+    config: Option<TimestampConfig>,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -308,6 +316,10 @@ async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
     let signing_preferences = load_signing_preferences();
     let (resolved_timestamp_url, resolved_timestamp_config, timestamp_source) =
         resolve_timestamp_settings(args.timestamp.as_deref(), &signing_preferences)?;
+    let timestamp_settings = TimestampSettings {
+        url: resolved_timestamp_url.clone(),
+        config: resolved_timestamp_config.clone(),
+    };
 
     // Parse slot
     let piv_slot = parse_piv_slot(&args.slot)
@@ -328,8 +340,7 @@ async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
                 piv_slot,
                 output_path,
                 remote_url,
-                resolved_timestamp_url,
-                resolved_timestamp_config,
+                &timestamp_settings,
             )
             .await;
         }
@@ -818,8 +829,7 @@ async fn handle_remote_sign(
     piv_slot: PivSlot,
     output_path: PathBuf,
     remote_url: &str,
-    timestamp_url: Option<TimestampUrl>,
-    timestamp_config: Option<TimestampConfig>,
+    timestamp_settings: &TimestampSettings,
 ) -> Result<()> {
     // Get proxy authentication token
     let auth_token = std::env::var("YUBIKEY_PROXY_TOKEN")
@@ -900,8 +910,7 @@ async fn handle_remote_sign(
             &cert_der,
             piv_slot,
             &additional_certs,
-            timestamp_url.as_ref(),
-            timestamp_config.as_ref(),
+            timestamp_settings,
             args.verbose,
         )
         .await?
@@ -912,8 +921,7 @@ async fn handle_remote_sign(
             &cert_der,
             piv_slot,
             &additional_certs,
-            timestamp_url.as_ref(),
-            timestamp_config.as_ref(),
+            timestamp_settings,
             args.verbose,
         )
         .await?
@@ -941,8 +949,7 @@ async fn handle_remote_pe_sign(
     cert_der: &[u8],
     piv_slot: PivSlot,
     additional_certs: &[Vec<u8>],
-    timestamp_url: Option<&TimestampUrl>,
-    timestamp_config: Option<&TimestampConfig>,
+    timestamp_settings: &TimestampSettings,
     verbose: bool,
 ) -> Result<Vec<u8>> {
     // Allow re-signing: if the input already contains an Authenticode certificate table,
@@ -981,7 +988,7 @@ async fn handle_remote_pe_sign(
     }
     // Get timestamp if requested
     let timestamp_token =
-        get_timestamp_if_requested(timestamp_url, timestamp_config, verbose, &signature).await?;
+        get_timestamp_if_requested(timestamp_settings, verbose, &signature).await?;
 
     // Create signed PE using preserved context
     let signed_pe = openssl_signer
@@ -1004,8 +1011,7 @@ async fn handle_remote_msi_sign(
     cert_der: &[u8],
     piv_slot: PivSlot,
     additional_certs: &[Vec<u8>],
-    timestamp_url: Option<&TimestampUrl>,
-    timestamp_config: Option<&TimestampConfig>,
+    timestamp_settings: &TimestampSettings,
     verbose: bool,
 ) -> Result<Vec<u8>> {
     // Create MSI signer with remote certificate and additional certs
@@ -1038,7 +1044,7 @@ async fn handle_remote_msi_sign(
 
     // Get timestamp if requested
     let timestamp_token =
-        get_timestamp_if_requested(timestamp_url, timestamp_config, verbose, &signature).await?;
+        get_timestamp_if_requested(timestamp_settings, verbose, &signature).await?;
 
     // Create signed MSI using preserved context
     let signed_msi = msi_signer
@@ -1056,16 +1062,15 @@ async fn handle_remote_msi_sign(
 
 /// Get timestamp token if timestamping is enabled.
 async fn get_timestamp_if_requested(
-    timestamp_url: Option<&TimestampUrl>,
-    timestamp_config: Option<&TimestampConfig>,
+    timestamp_settings: &TimestampSettings,
     verbose: bool,
     signature: &[u8],
 ) -> Result<Option<Vec<u8>>> {
-    if let Some(ts_url) = timestamp_url {
+    if let Some(ts_url) = timestamp_settings.url.as_ref() {
         if verbose {
             println!("[*] Fetching timestamp from {}...", ts_url.as_str());
         }
-        let ts_client = if let Some(ts_cfg) = timestamp_config {
+        let ts_client = if let Some(ts_cfg) = timestamp_settings.config.as_ref() {
             TimestampClient::with_config(ts_cfg.clone())
         } else {
             TimestampClient::new(ts_url)
@@ -1119,6 +1124,7 @@ fn resolve_timestamp_settings(
     prefs: &SigningConfiguration,
 ) -> Result<(Option<TimestampUrl>, Option<TimestampConfig>, &'static str)> {
     match cli_timestamp {
+        Some(raw) if raw == TIMESTAMP_USE_CONFIG_SENTINEL => resolve_timestamp_from_config(prefs),
         Some(raw) if raw.trim().is_empty() => Ok((None, None, "cli-disabled")),
         Some(raw) => {
             let primary = TimestampUrl::new(raw)
@@ -1133,33 +1139,38 @@ fn resolve_timestamp_settings(
             };
             Ok((Some(primary), Some(config), "cli"))
         }
-        None => {
-            let primary = TimestampUrl::new(&prefs.primary_timestamp_server)
-                .into_diagnostic()
-                .context("Invalid primary timestamp server in configuration")?;
-
-            let fallback_servers = prefs
-                .fallback_timestamp_servers
-                .iter()
-                .map(|url| {
-                    TimestampUrl::new(url)
-                        .map_err(miette::Report::from)
-                        .with_context(|| {
-                            format!("Invalid fallback timestamp server in configuration: {url}")
-                        })
-                })
-                .collect::<Result<Vec<_>>>()?;
-
-            let config = TimestampConfig {
-                primary_server: primary.clone(),
-                fallback_servers,
-                timeout: Duration::from_secs(prefs.network_timeout_seconds),
-                retry_attempts: prefs.retry_attempts,
-                retry_delay: Duration::from_secs(2),
-            };
-            Ok((Some(primary), Some(config), "config"))
-        }
+        None => resolve_timestamp_from_config(prefs),
     }
+}
+
+fn resolve_timestamp_from_config(
+    prefs: &SigningConfiguration,
+) -> Result<(Option<TimestampUrl>, Option<TimestampConfig>, &'static str)> {
+    let primary = TimestampUrl::new(&prefs.primary_timestamp_server)
+        .into_diagnostic()
+        .context("Invalid primary timestamp server in configuration")?;
+
+    let fallback_servers = prefs
+        .fallback_timestamp_servers
+        .iter()
+        .map(|url| {
+            TimestampUrl::new(url)
+                .map_err(miette::Report::from)
+                .with_context(|| {
+                    format!("Invalid fallback timestamp server in configuration: {url}")
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let config = TimestampConfig {
+        primary_server: primary.clone(),
+        fallback_servers,
+        timeout: Duration::from_secs(prefs.network_timeout_seconds),
+        retry_attempts: prefs.retry_attempts,
+        retry_delay: Duration::from_secs(2),
+    };
+
+    Ok((Some(primary), Some(config), "config"))
 }
 
 #[cfg(test)]
@@ -1201,5 +1212,21 @@ mod tests {
         assert_eq!(source, "cli-disabled");
         assert!(url.is_none());
         assert!(config.is_none());
+    }
+
+    #[test]
+    fn resolve_timestamp_settings_cli_flag_without_value_uses_config() {
+        let prefs = SigningConfiguration::default();
+        let (url, config, source) =
+            resolve_timestamp_settings(Some(TIMESTAMP_USE_CONFIG_SENTINEL), &prefs).unwrap();
+        assert_eq!(source, "config");
+        assert_eq!(
+            url.as_ref().map(TimestampUrl::as_str),
+            Some(prefs.primary_timestamp_server.as_str())
+        );
+        assert_eq!(
+            config.as_ref().map(|c| c.fallback_servers.len()),
+            Some(prefs.fallback_timestamp_servers.len())
+        );
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -38,14 +38,15 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use miette::{Context, IntoDiagnostic, Result};
 use std::path::PathBuf;
+use std::time::Duration;
 use yubikey_signer::{
     adapters::remote::client::{RemoteSigner, RemoteSignerConfig},
     domain::msi::is_msi_file,
-    infra::config::{ConfigManager, ExportFormat},
+    infra::config::{ConfigManager, ExportFormat, SigningConfiguration},
     infra::error::SigningError,
     services::authenticode::OpenSslAuthenticodeSigner,
     services::msi_signer::MsiSigner,
-    services::timestamp::TimestampClient,
+    services::timestamp::{TimestampClient, TimestampConfig},
     HashAlgorithm, PivSlot, TimestampUrl,
 };
 
@@ -304,6 +305,10 @@ async fn main() -> Result<()> {
 }
 
 async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
+    let signing_preferences = load_signing_preferences();
+    let (resolved_timestamp_url, resolved_timestamp_config, timestamp_source) =
+        resolve_timestamp_settings(args.timestamp.as_deref(), &signing_preferences)?;
+
     // Parse slot
     let piv_slot = parse_piv_slot(&args.slot)
         .into_diagnostic()
@@ -318,7 +323,15 @@ async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
     // Check if we're using remote signing (only if URL is non-empty)
     if let Some(ref remote_url) = args.remote {
         if !remote_url.is_empty() {
-            return handle_remote_sign(&args, piv_slot, output_path, remote_url).await;
+            return handle_remote_sign(
+                &args,
+                piv_slot,
+                output_path,
+                remote_url,
+                resolved_timestamp_url,
+                resolved_timestamp_config,
+            )
+            .await;
         }
     }
 
@@ -346,11 +359,7 @@ async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
         let signing_config = SigningConfig {
             pin: PivPin::new(pin).into_diagnostic()?,
             piv_slot,
-            timestamp_url: args
-                .timestamp
-                .map(TimestampUrl::new)
-                .transpose()
-                .into_diagnostic()?,
+            timestamp_url: resolved_timestamp_url.clone(),
             hash_algorithm: HashAlgorithm::Sha256, // Auto-detected, this is just a default
             embed_certificate: true,
             additional_certs,
@@ -369,6 +378,7 @@ async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
             }
             if let Some(ref ts_url) = signing_config.timestamp_url {
                 println!("  Timestamp server: {}", ts_url.as_str());
+                println!("  Timestamp source: {timestamp_source}");
             } else {
                 println!("  Timestamp: disabled");
             }
@@ -401,10 +411,19 @@ async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
         let config_clone = signing_config.clone();
         let result = if is_msi {
             // Local MSI signing
-            handle_local_msi_sign(&file_data, &output_path, &signing_config).await
+            handle_local_msi_sign(
+                &file_data,
+                &output_path,
+                &signing_config,
+                resolved_timestamp_config.as_ref(),
+            )
+            .await
         } else {
             // Local PE signing
-            let workflow = SignWorkflow::new(signing_config.hash_algorithm);
+            let workflow = SignWorkflow::new_with_timestamp_config(
+                signing_config.hash_algorithm,
+                resolved_timestamp_config,
+            );
             workflow
                 .sign_pe_file(&args.input_file, &output_path, signing_config)
                 .await
@@ -452,6 +471,7 @@ async fn handle_local_msi_sign(
     msi_data: &[u8],
     output_path: &std::path::Path,
     config: &SigningConfig,
+    timestamp_config: Option<&TimestampConfig>,
 ) -> Result<()> {
     use miette::IntoDiagnostic;
 
@@ -496,7 +516,11 @@ async fn handle_local_msi_sign(
     // Get timestamp if requested
     let timestamp_token = if let Some(ref ts_url) = config.timestamp_url {
         log::info!("Requesting timestamp from {}", ts_url.as_str());
-        let ts_client = TimestampClient::default();
+        let ts_client = if let Some(ts_cfg) = timestamp_config {
+            TimestampClient::with_config(ts_cfg.clone())
+        } else {
+            TimestampClient::new(ts_url)
+        };
         Some(
             ts_client
                 .get_timestamp(&signature)
@@ -794,6 +818,8 @@ async fn handle_remote_sign(
     piv_slot: PivSlot,
     output_path: PathBuf,
     remote_url: &str,
+    timestamp_url: Option<TimestampUrl>,
+    timestamp_config: Option<TimestampConfig>,
 ) -> Result<()> {
     // Get proxy authentication token
     let auth_token = std::env::var("YUBIKEY_PROXY_TOKEN")
@@ -869,22 +895,26 @@ async fn handle_remote_sign(
     // Route to appropriate signer based on file type
     let signed_data = if is_msi {
         handle_remote_msi_sign(
-            args,
             &file_data,
             &client,
             &cert_der,
             piv_slot,
             &additional_certs,
+            timestamp_url.as_ref(),
+            timestamp_config.as_ref(),
+            args.verbose,
         )
         .await?
     } else {
         handle_remote_pe_sign(
-            args,
             &file_data,
             &client,
             &cert_der,
             piv_slot,
             &additional_certs,
+            timestamp_url.as_ref(),
+            timestamp_config.as_ref(),
+            args.verbose,
         )
         .await?
     };
@@ -906,12 +936,14 @@ async fn handle_remote_sign(
 
 /// Handle remote PE signing.
 async fn handle_remote_pe_sign(
-    args: &SignCommandArgs,
     pe_data: &[u8],
     client: &RemoteSigner,
     cert_der: &[u8],
     piv_slot: PivSlot,
     additional_certs: &[Vec<u8>],
+    timestamp_url: Option<&TimestampUrl>,
+    timestamp_config: Option<&TimestampConfig>,
+    verbose: bool,
 ) -> Result<Vec<u8>> {
     // Allow re-signing: if the input already contains an Authenticode certificate table,
     // strip it before computing the TBS/PE hash so the signature corresponds to the unsigned
@@ -927,7 +959,7 @@ async fn handle_remote_pe_sign(
         .with_additional_certs(additional_certs.to_vec());
 
     // Compute TBS (to-be-signed) hash locally with context
-    if args.verbose {
+    if verbose {
         println!("[*] Computing TBS hash (authenticated attributes)...");
     }
     let tbs_context = openssl_signer
@@ -935,7 +967,7 @@ async fn handle_remote_pe_sign(
         .into_diagnostic()?;
 
     // Sign TBS hash remotely
-    if args.verbose {
+    if verbose {
         println!("[*] Signing TBS hash remotely...");
     }
     let signature = client
@@ -944,11 +976,12 @@ async fn handle_remote_pe_sign(
         .into_diagnostic()?;
 
     // Build PKCS7 locally with remote signature
-    if args.verbose {
+    if verbose {
         println!("[*] Building PKCS7 structure...");
     }
     // Get timestamp if requested
-    let timestamp_token = get_timestamp_if_requested(args, &signature).await?;
+    let timestamp_token =
+        get_timestamp_if_requested(timestamp_url, timestamp_config, verbose, &signature).await?;
 
     // Create signed PE using preserved context
     let signed_pe = openssl_signer
@@ -966,12 +999,14 @@ async fn handle_remote_pe_sign(
 
 /// Handle remote MSI signing.
 async fn handle_remote_msi_sign(
-    args: &SignCommandArgs,
     msi_data: &[u8],
     client: &RemoteSigner,
     cert_der: &[u8],
     piv_slot: PivSlot,
     additional_certs: &[Vec<u8>],
+    timestamp_url: Option<&TimestampUrl>,
+    timestamp_config: Option<&TimestampConfig>,
+    verbose: bool,
 ) -> Result<Vec<u8>> {
     // Create MSI signer with remote certificate and additional certs
     let msi_signer = MsiSigner::new(cert_der, HashAlgorithm::Sha256)
@@ -980,7 +1015,7 @@ async fn handle_remote_msi_sign(
         .with_additional_certs(additional_certs.to_vec());
 
     // Compute TBS (to-be-signed) hash locally with context
-    if args.verbose {
+    if verbose {
         println!("[*] Computing MSI TBS hash (authenticated attributes)...");
     }
     let tbs_context = msi_signer
@@ -988,7 +1023,7 @@ async fn handle_remote_msi_sign(
         .into_diagnostic()?;
 
     // Sign TBS hash remotely
-    if args.verbose {
+    if verbose {
         println!("[*] Signing TBS hash remotely...");
     }
     let signature = client
@@ -997,12 +1032,13 @@ async fn handle_remote_msi_sign(
         .into_diagnostic()?;
 
     // Build PKCS7 locally with remote signature
-    if args.verbose {
+    if verbose {
         println!("[*] Building PKCS7 structure for MSI...");
     }
 
     // Get timestamp if requested
-    let timestamp_token = get_timestamp_if_requested(args, &signature).await?;
+    let timestamp_token =
+        get_timestamp_if_requested(timestamp_url, timestamp_config, verbose, &signature).await?;
 
     // Create signed MSI using preserved context
     let signed_msi = msi_signer
@@ -1018,21 +1054,152 @@ async fn handle_remote_msi_sign(
     Ok(signed_msi.into_bytes())
 }
 
-/// Get timestamp token if requested in arguments.
+/// Get timestamp token if timestamping is enabled.
 async fn get_timestamp_if_requested(
-    args: &SignCommandArgs,
+    timestamp_url: Option<&TimestampUrl>,
+    timestamp_config: Option<&TimestampConfig>,
+    verbose: bool,
     signature: &[u8],
 ) -> Result<Option<Vec<u8>>> {
-    if let Some(ref ts_url) = args.timestamp {
-        if args.verbose {
-            println!("[*] Fetching timestamp from {ts_url}...");
+    if let Some(ts_url) = timestamp_url {
+        if verbose {
+            println!("[*] Fetching timestamp from {}...", ts_url.as_str());
         }
-        let ts_url_typed = TimestampUrl::new(ts_url).into_diagnostic()?;
-        let ts_client = TimestampClient::new(&ts_url_typed);
+        let ts_client = if let Some(ts_cfg) = timestamp_config {
+            TimestampClient::with_config(ts_cfg.clone())
+        } else {
+            TimestampClient::new(ts_url)
+        };
         Ok(Some(
             ts_client.get_timestamp(signature).await.into_diagnostic()?,
         ))
     } else {
         Ok(None)
+    }
+}
+
+/// Load signing preferences for `sign` command.
+///
+/// Falls back to in-memory defaults if config file is missing or invalid.
+///
+/// # Returns
+///
+/// Effective signing preferences loaded from disk when available,
+/// otherwise default preferences.
+fn load_signing_preferences() -> SigningConfiguration {
+    ConfigManager::new()
+        .ok()
+        .and_then(|manager| manager.load().ok())
+        .unwrap_or_default()
+}
+
+/// Resolve effective timestamp settings using CLI overrides and persisted configuration.
+///
+/// Precedence rules:
+/// - `--timestamp ""` disables timestamping
+/// - `--timestamp <URL>` enables timestamping with explicit URL as primary and no fallbacks
+/// - no CLI timestamp flag uses configuration primary/fallback servers
+///
+/// # Arguments
+///
+/// * `cli_timestamp` - Optional CLI timestamp value from `--timestamp`
+/// * `prefs` - Loaded signing preferences containing timestamp defaults
+///
+/// # Returns
+///
+/// Tuple of `(effective_url, effective_timestamp_config, source_label)`.
+/// `effective_url` is `None` when timestamping is explicitly disabled.
+/// `source_label` indicates whether values came from CLI, config, or explicit disable.
+///
+/// # Errors
+///
+/// Returns an error when the CLI or persisted timestamp URLs are invalid.
+fn resolve_timestamp_settings(
+    cli_timestamp: Option<&str>,
+    prefs: &SigningConfiguration,
+) -> Result<(Option<TimestampUrl>, Option<TimestampConfig>, &'static str)> {
+    match cli_timestamp {
+        Some(raw) if raw.trim().is_empty() => Ok((None, None, "cli-disabled")),
+        Some(raw) => {
+            let primary = TimestampUrl::new(raw)
+                .into_diagnostic()
+                .context("Invalid --timestamp URL")?;
+            let config = TimestampConfig {
+                primary_server: primary.clone(),
+                fallback_servers: vec![],
+                timeout: Duration::from_secs(prefs.network_timeout_seconds),
+                retry_attempts: prefs.retry_attempts,
+                retry_delay: Duration::from_secs(2),
+            };
+            Ok((Some(primary), Some(config), "cli"))
+        }
+        None => {
+            let primary = TimestampUrl::new(&prefs.primary_timestamp_server)
+                .into_diagnostic()
+                .context("Invalid primary timestamp server in configuration")?;
+
+            let fallback_servers = prefs
+                .fallback_timestamp_servers
+                .iter()
+                .map(|url| {
+                    TimestampUrl::new(url)
+                        .map_err(miette::Report::from)
+                        .with_context(|| {
+                            format!("Invalid fallback timestamp server in configuration: {url}")
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let config = TimestampConfig {
+                primary_server: primary.clone(),
+                fallback_servers,
+                timeout: Duration::from_secs(prefs.network_timeout_seconds),
+                retry_attempts: prefs.retry_attempts,
+                retry_delay: Duration::from_secs(2),
+            };
+            Ok((Some(primary), Some(config), "config"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_timestamp_settings_uses_config_when_cli_missing() {
+        let prefs = SigningConfiguration::default();
+        let (url, config, source) = resolve_timestamp_settings(None, &prefs).unwrap();
+        assert_eq!(source, "config");
+        assert_eq!(
+            url.as_ref().map(TimestampUrl::as_str),
+            Some(prefs.primary_timestamp_server.as_str())
+        );
+        assert_eq!(
+            config.as_ref().map(|c| c.fallback_servers.len()),
+            Some(prefs.fallback_timestamp_servers.len())
+        );
+    }
+
+    #[test]
+    fn resolve_timestamp_settings_uses_cli_override_without_fallbacks() {
+        let prefs = SigningConfiguration::default();
+        let (url, config, source) =
+            resolve_timestamp_settings(Some("http://timestamp.digicert.com"), &prefs).unwrap();
+        assert_eq!(source, "cli");
+        assert_eq!(
+            url.as_ref().map(TimestampUrl::as_str),
+            Some("http://timestamp.digicert.com")
+        );
+        assert_eq!(config.as_ref().map(|c| c.fallback_servers.len()), Some(0));
+    }
+
+    #[test]
+    fn resolve_timestamp_settings_allows_explicit_disable() {
+        let prefs = SigningConfiguration::default();
+        let (url, config, source) = resolve_timestamp_settings(Some(""), &prefs).unwrap();
+        assert_eq!(source, "cli-disabled");
+        assert!(url.is_none());
+        assert!(config.is_none());
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -117,8 +117,6 @@ struct Cli {
     command: Commands,
 }
 
-const TIMESTAMP_USE_CONFIG_SENTINEL: &str = "__USE_CONFIG_DEFAULTS__";
-
 #[derive(Subcommand)]
 enum Commands {
     /// Sign a PE or MSI file
@@ -135,9 +133,13 @@ enum Commands {
         #[arg(short, long, value_name = "SLOT", default_value = "9a")]
         slot: String,
 
-        /// Timestamp server URL (omit value to use configuration defaults)
-        #[arg(short, long, value_name = "URL", num_args = 0..=1, default_missing_value = "__USE_CONFIG_DEFAULTS__")]
+        /// Timestamp server URL override (when absent, configured defaults apply)
+        #[arg(short, long, value_name = "URL")]
         timestamp: Option<String>,
+
+        /// Explicitly disable timestamping (overrides configuration defaults)
+        #[arg(long, conflicts_with = "timestamp")]
+        no_timestamp: bool,
 
         /// Remote `YubiKey` proxy URL (e.g., <https://yubikey.example.com>)
         #[arg(long, value_name = "URL", env = "YUBIKEY_PROXY_URL")]
@@ -241,6 +243,7 @@ struct SignCommandArgs {
     output: Option<PathBuf>,
     slot: String,
     timestamp: Option<String>,
+    no_timestamp: bool,
     remote: Option<String>,
     headers: Vec<String>,
     additional_certs: Vec<PathBuf>,
@@ -279,6 +282,7 @@ async fn main() -> Result<()> {
             output,
             slot,
             timestamp,
+            no_timestamp,
             remote,
             headers,
             additional_certs,
@@ -290,6 +294,7 @@ async fn main() -> Result<()> {
                 output,
                 slot,
                 timestamp,
+                no_timestamp,
                 remote,
                 headers,
                 additional_certs,
@@ -315,7 +320,11 @@ async fn main() -> Result<()> {
 async fn handle_sign_command(args: SignCommandArgs) -> Result<()> {
     let signing_preferences = load_signing_preferences();
     let (resolved_timestamp_url, resolved_timestamp_config, timestamp_source) =
-        resolve_timestamp_settings(args.timestamp.as_deref(), &signing_preferences)?;
+        resolve_timestamp_settings(
+            args.timestamp.as_deref(),
+            args.no_timestamp,
+            &signing_preferences,
+        )?;
     let timestamp_settings = TimestampSettings {
         url: resolved_timestamp_url.clone(),
         config: resolved_timestamp_config.clone(),
@@ -1101,13 +1110,14 @@ fn load_signing_preferences() -> SigningConfiguration {
 /// Resolve effective timestamp settings using CLI overrides and persisted configuration.
 ///
 /// Precedence rules:
-/// - `--timestamp ""` disables timestamping
-/// - `--timestamp <URL>` enables timestamping with explicit URL as primary and no fallbacks
-/// - no CLI timestamp flag uses configuration primary/fallback servers
+/// - `--no-timestamp` disables timestamping
+/// - `--timestamp <URL>` enables timestamping with the given URL as primary (no fallbacks)
+/// - neither flag present uses configuration primary/fallback servers
 ///
 /// # Arguments
 ///
-/// * `cli_timestamp` - Optional CLI timestamp value from `--timestamp`
+/// * `cli_timestamp` - Optional explicit URL from `--timestamp <URL>`
+/// * `no_timestamp` - Whether `--no-timestamp` was passed
 /// * `prefs` - Loaded signing preferences containing timestamp defaults
 ///
 /// # Returns
@@ -1121,13 +1131,16 @@ fn load_signing_preferences() -> SigningConfiguration {
 /// Returns an error when the CLI or persisted timestamp URLs are invalid.
 fn resolve_timestamp_settings(
     cli_timestamp: Option<&str>,
+    no_timestamp: bool,
     prefs: &SigningConfiguration,
 ) -> Result<(Option<TimestampUrl>, Option<TimestampConfig>, &'static str)> {
+    if no_timestamp {
+        return Ok((None, None, "cli-disabled"));
+    }
     match cli_timestamp {
-        Some(raw) if raw == TIMESTAMP_USE_CONFIG_SENTINEL => resolve_timestamp_from_config(prefs),
-        Some(raw) if raw.trim().is_empty() => Ok((None, None, "cli-disabled")),
         Some(raw) => {
-            let primary = TimestampUrl::new(raw)
+            let trimmed = raw.trim();
+            let primary = TimestampUrl::new(trimmed)
                 .into_diagnostic()
                 .context("Invalid --timestamp URL")?;
             let config = TimestampConfig {
@@ -1180,7 +1193,7 @@ mod tests {
     #[test]
     fn resolve_timestamp_settings_uses_config_when_cli_missing() {
         let prefs = SigningConfiguration::default();
-        let (url, config, source) = resolve_timestamp_settings(None, &prefs).unwrap();
+        let (url, config, source) = resolve_timestamp_settings(None, false, &prefs).unwrap();
         assert_eq!(source, "config");
         assert_eq!(
             url.as_ref().map(TimestampUrl::as_str),
@@ -1196,7 +1209,8 @@ mod tests {
     fn resolve_timestamp_settings_uses_cli_override_without_fallbacks() {
         let prefs = SigningConfiguration::default();
         let (url, config, source) =
-            resolve_timestamp_settings(Some("http://timestamp.digicert.com"), &prefs).unwrap();
+            resolve_timestamp_settings(Some("http://timestamp.digicert.com"), false, &prefs)
+                .unwrap();
         assert_eq!(source, "cli");
         assert_eq!(
             url.as_ref().map(TimestampUrl::as_str),
@@ -1206,27 +1220,24 @@ mod tests {
     }
 
     #[test]
-    fn resolve_timestamp_settings_allows_explicit_disable() {
+    fn resolve_timestamp_settings_no_timestamp_flag_disables() {
         let prefs = SigningConfiguration::default();
-        let (url, config, source) = resolve_timestamp_settings(Some(""), &prefs).unwrap();
+        let (url, config, source) = resolve_timestamp_settings(None, true, &prefs).unwrap();
         assert_eq!(source, "cli-disabled");
         assert!(url.is_none());
         assert!(config.is_none());
     }
 
     #[test]
-    fn resolve_timestamp_settings_cli_flag_without_value_uses_config() {
+    fn resolve_timestamp_settings_trims_whitespace_from_url() {
         let prefs = SigningConfiguration::default();
-        let (url, config, source) =
-            resolve_timestamp_settings(Some(TIMESTAMP_USE_CONFIG_SENTINEL), &prefs).unwrap();
-        assert_eq!(source, "config");
+        let (url, _, source) =
+            resolve_timestamp_settings(Some("  http://timestamp.digicert.com  "), false, &prefs)
+                .unwrap();
+        assert_eq!(source, "cli");
         assert_eq!(
             url.as_ref().map(TimestampUrl::as_str),
-            Some(prefs.primary_timestamp_server.as_str())
-        );
-        assert_eq!(
-            config.as_ref().map(|c| c.fallback_servers.len()),
-            Some(prefs.fallback_timestamp_servers.len())
+            Some("http://timestamp.digicert.com")
         );
     }
 }

--- a/src/pipelines/sign.rs
+++ b/src/pipelines/sign.rs
@@ -126,10 +126,11 @@ impl SignWorkflow {
             let timestamp_client = if let Some(ts_config) = self.timestamp_config.clone() {
                 TimestampClient::with_config(ts_config)
             } else {
-                let ts_url = config
-                    .timestamp_url
-                    .as_ref()
-                    .expect("timestamp_url must be present when want_timestamp is true");
+                let ts_url = config.timestamp_url.as_ref().ok_or_else(|| {
+                    SigningError::TimestampError(
+                        "Timestamping requested but no timestamp server is configured".to_string(),
+                    )
+                })?;
                 TimestampClient::new(ts_url)
             };
             let timestamp_token = timestamp_client.get_timestamp(&signature).await?;

--- a/src/pipelines/sign.rs
+++ b/src/pipelines/sign.rs
@@ -10,6 +10,7 @@ use crate::{
         attr_builder::AttrBuilderService, authenticode::OpenSslAuthenticodeSigner,
         embedder::PeSignatureEmbedderService, pe_hasher::PeHasher,
         pkcs7_builder::Pkcs7BuilderService, spc_builder::SpcBuilderService,
+        timestamp::TimestampConfig,
     },
     SigningConfig,
     SigningError,
@@ -20,12 +21,28 @@ use std::path::Path;
 
 pub struct SignWorkflow {
     hash_algorithm: HashAlgorithm,
+    timestamp_config: Option<TimestampConfig>,
 }
 
 impl SignWorkflow {
     #[must_use]
     pub fn new(hash_algorithm: HashAlgorithm) -> Self {
-        Self { hash_algorithm }
+        Self {
+            hash_algorithm,
+            timestamp_config: None,
+        }
+    }
+
+    /// Create a workflow that uses the provided timestamp configuration.
+    #[must_use]
+    pub fn new_with_timestamp_config(
+        hash_algorithm: HashAlgorithm,
+        timestamp_config: Option<TimestampConfig>,
+    ) -> Self {
+        Self {
+            hash_algorithm,
+            timestamp_config,
+        }
     }
 
     #[must_use]
@@ -105,9 +122,16 @@ impl SignWorkflow {
             log::info!("Using authenticode path for timestamped signing");
 
             // Get timestamp token first
-            use crate::services::timestamp::{TimestampClient, TimestampConfig};
-            let ts_config = TimestampConfig::default();
-            let timestamp_client = TimestampClient::with_config(ts_config);
+            use crate::services::timestamp::TimestampClient;
+            let timestamp_client = if let Some(ts_config) = self.timestamp_config.clone() {
+                TimestampClient::with_config(ts_config)
+            } else if let Some(ts_url) = config.timestamp_url.as_ref() {
+                TimestampClient::new(ts_url)
+            } else {
+                return Err(SigningError::TimestampError(
+                    "Timestamping requested but no timestamp server is configured".to_string(),
+                ));
+            };
             let timestamp_token = timestamp_client.get_timestamp(&signature).await?;
 
             let authenticode_signer =
@@ -150,6 +174,15 @@ mod tests {
     fn construct_workflow() {
         let wf = SignWorkflow::new(HashAlgorithm::Sha256);
         assert!(matches!(wf.hash_algorithm, HashAlgorithm::Sha256));
+        assert!(wf.timestamp_config.is_none());
+    }
+
+    #[test]
+    fn construct_workflow_with_timestamp_config() {
+        let ts_config = TimestampConfig::default();
+        let wf = SignWorkflow::new_with_timestamp_config(HashAlgorithm::Sha256, Some(ts_config));
+        assert!(matches!(wf.hash_algorithm, HashAlgorithm::Sha256));
+        assert!(wf.timestamp_config.is_some());
     }
 
     // Integration tests with hardware are in tests/ directory

--- a/src/pipelines/sign.rs
+++ b/src/pipelines/sign.rs
@@ -125,12 +125,12 @@ impl SignWorkflow {
             use crate::services::timestamp::TimestampClient;
             let timestamp_client = if let Some(ts_config) = self.timestamp_config.clone() {
                 TimestampClient::with_config(ts_config)
-            } else if let Some(ts_url) = config.timestamp_url.as_ref() {
-                TimestampClient::new(ts_url)
             } else {
-                return Err(SigningError::TimestampError(
-                    "Timestamping requested but no timestamp server is configured".to_string(),
-                ));
+                let ts_url = config
+                    .timestamp_url
+                    .as_ref()
+                    .expect("timestamp_url must be present when want_timestamp is true");
+                TimestampClient::new(ts_url)
             };
             let timestamp_token = timestamp_client.get_timestamp(&signature).await?;
 


### PR DESCRIPTION
## Summary
This PR makes timestamp behavior for `sign` consistent and config-aware.

- uses configured timestamp defaults when `--timestamp` is not provided
- keeps explicit CLI override behavior for `--timestamp <URL>`
- adds explicit disable via `--no-timestamp`
- removes the internal `--timestamp` sentinel/default-missing-value ambiguity
- trims surrounding whitespace on CLI timestamp URLs before validation
- removes panic risk in non-test code by replacing `.expect(...)` with structured `SigningError`
- removes remaining hardcoded default timestamp client fallback in local timestamped PE path
- aligns comprehensive test script to explicitly disable timestamping in non-timestamped test scenarios
- bumps crate version to `0.7.6`

## Issue linkage
- refs #96
- Fixes #100

## Validation
- `cargo clippy` (0 errors)
- `cargo test` (161 passed, 27 ignored)
- `cargo deny --log-level error check --hide-inclusion-graph` (advisories/bans/licenses/sources ok)
- `./scripts/test.ps1` (10/10 passed)
